### PR TITLE
Add new bookmark for learning nix in floorp

### DIFF
--- a/modules/programs/browser/floorp/bookmarks.nix
+++ b/modules/programs/browser/floorp/bookmarks.nix
@@ -84,6 +84,10 @@
             url = "https://nix.dev/";
           }
           {
+            name = "Interactive Nix Lessons";
+            url = "https://nixcloud.io/tour/?id=introduction/nix";
+          }
+          {
             name = "NixOS & Flakes Book";
             url = "https://nixos-and-flakes.thiscute.world/";
           }


### PR DESCRIPTION
This commit will:
- Add Tour of Nix as a bookmark under the NixOS section in floorp browser