### PR TITLE
Update go version to 1.24 in dev-shell  flake

### DIFF
--- a/dev-shells/go/flake.nix
+++ b/dev-shells/go/flake.nix
@@ -1,11 +1,11 @@
 {
-  description = "A Nix-flake-based Go 1.22 development environment";
+  description = "A Nix-flake-based Go 1.24 development environment";
 
   inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
 
   outputs = { self, nixpkgs }:
     let
-      goVersion = 22; # Change this to update the whole stack
+      goVersion = 24; # Change this to update the whole stack
 
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {


### PR DESCRIPTION
This commit will:
- Update the go version in dev-shell because the previous version is deprecated.