### PR TITLE
bluetooth: disable auto headset profile switching

### DIFF
--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -206,7 +206,14 @@
     alsa.enable = true;
     alsa.support32Bit = true;
     pulse.enable = true;
-    wireplumber.enable = true;
+    wireplumber = {
+      enable = true;
+      configPackages = [
+        (pkgs.writeTextDir "share/wireplumber/wireplumber.conf.d/11-bluetooth-policy.conf" ''
+          bluetooth.autoswitch-to-headset-profile = false
+        '')
+      ];
+    };
   };
 
   services.xserver.enable = true; # Enable the X11 windowing system.


### PR DESCRIPTION
Bluetooth headset HSP/HFP profiles will no longer be automatically activated. 
This prevents audio quality degradation unless the profile is manually changed.