### PR TITLE
waybar fix format error

### DIFF
--- a/modules/desktop/hyprland/programs/waybar/default.nix
+++ b/modules/desktop/hyprland/programs/waybar/default.nix
@@ -187,7 +187,7 @@
               format-alt = "󰾅 {used}GB";
               max-length = 10;
               tooltip = true;
-              tooltip-format = " {used =0.1f}GB/{total =0.1f}GB";
+              tooltip-format = " {used:.1f}GB/{total:.1f}GB";
             };
 
             "backlight" = {


### PR DESCRIPTION
[error] memory: missing '}' in format string

Waybar was giving errors in the background. Occasionally it becomes unresponsive.
This is the solution to the error I saw.

I'm not sure if this is the cause of the occasional unresponsiveness.

