### PR TITLE
hyprland exec hyprpaper removed

### DIFF
--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -117,7 +117,6 @@
             #"[workspace special silent] ${browser} --private-window"
             #"[workspace special silent] ${terminal}"
 
-            "hyprpaper"
             "waybar"
             "swaync"
             "nm-applet --indicator"


### PR DESCRIPTION
It was causing conflicts because it was run with catpuccin. 
It was constantly giving errors in the background.

Unnecessary for the default configuration.