### PR TITLE
Nvidia Cuda Support

### DIFF
--- a/modules/hardware/video/nvidia.nix
+++ b/modules/hardware/video/nvidia.nix
@@ -45,6 +45,7 @@ in {
   };
   nixpkgs.config = {
     nvidia.acceptLicense = true;
+    cudaSupport = true;
     allowUnfreePredicate = pkg:
       builtins.elem (lib.getName pkg) [
         "cudatoolkit"


### PR DESCRIPTION
While I was trying to record my screen with OBS, I realized that I couldn't see the NVIDIA NVENC options.