### PR TITLE
fix direnv: disable nix-direnv to prevent failed execve syscalls

### DIFF
--- a/modules/programs/cli/direnv/default.nix
+++ b/modules/programs/cli/direnv/default.nix
@@ -5,11 +5,10 @@
     (_: {
       programs.direnv = {
         enable = true;
-        nix-direnv.enable = true;
         enableBashIntegration = true;
         enableZshIntegration = true;
-        enableFishIntegration = true;
-        enableNushellIntegration = true;
+        enableFishIntegration = false;
+        enableNushellIntegration = false;
       };
       # home.sessionVariables = {
       #   # DIRENV_DIR = "/tmp/direnv";


### PR DESCRIPTION
## QuickFix for Direnv

The current direnv config causes thousands of  `execve` syscalls daily, which clogs up auditors/logs. 

 `nix-direnv.enable = true` adds standard Nix package manager paths (`~/.nix-profile/bin`, `/nix/profile/bin`, etc.) to PATH, but these directories don't exist on NixOS.
 
 So I removed that line. Tested and working, plus no more spam.

https://github.com/nix-community/nix-direnv?tab=readme-ov-file#via-system-configuration-on-nixos
All that's needed is `programs.direnv.enable = true` 
