### PR TITLE
Update amdgpu.nix

### DIFF
--- a/modules/hardware/video/amdgpu.nix
+++ b/modules/hardware/video/amdgpu.nix
@@ -1,24 +1,14 @@
 { pkgs, ... }:
+
 {
+  services.xserver.videoDrivers = [ "amdgpu" ];
   services.xserver = {
     enable = true;
     videoDrivers = [ "amdgpu" ];
   };
   environment.systemPackages = with pkgs; [ rocmPackages.amdsmi ];
-  # TODO: Use this instead of hardware.graphics
-  # Can't test since i have nvidia
+  environment.systemPackages = with pkgs; [ rocmPackages.amdsmi ];
    hardware.amdgpu = {
      opencl.enable = true;
    };
-
-  #hardware.graphics = {
-  #  enable = true;
-  #  enable32Bit = true;
-  #  extraPackages = with pkgs; [
-  #    amdvlk
-  #    libvdpau-va-gl
-  #    vaapiVdpau
-  #  ];
-  #  extraPackages32 = with pkgs; [ driversi686Linux.amdvlk ];
-  #};
 }


### PR DESCRIPTION
i guess nobody really uses amdgpu option since it's nvidia by default :
i ran into issues while running some pytorch , tried to switch to amdgpu with the following error on rebuild 

error: 'amdvlk' has been removed since it was deprecated by AMD. Its replacement, RADV, is enabled by default.

so here goes some line deletion 

now rebuilds without fail with a rx460 
