### PR TITLE
Comment out the redundant declaration of xserver

### DIFF
--- a/modules/hardware/video/amdgpu.nix
+++ b/modules/hardware/video/amdgpu.nix
@@ -2,7 +2,7 @@
 
 {
   services.xserver = {
-    enable = true;
+    # enable = true;  # Already enabled in display manager
     videoDrivers = [ "amdgpu" ];
   };
   environment.systemPackages = with pkgs; [ rocmPackages.amdsmi ];


### PR DESCRIPTION
Since x-server is already enabled elsewhere, this causes an error. 