### PR TITLE
Add initial password for new users

### DIFF
--- a/modules/core/users.nix
+++ b/modules/core/users.nix
@@ -48,6 +48,7 @@ in
     mutableUsers = true;
     users.${username} = {
       isNormalUser = true;
+      initialPassword = "123";
       extraGroups = [
         "wheel" # sudo access
         "input"


### PR DESCRIPTION
This helps prevent locking out new users because when a new user is created through the dotfiles, our passwd is not copied to that user. This is an issue we will have to fix in the future, but for now this helps.