### PR TITLE
update vaapiIntel alias to intel-vaapi-driver

### DIFF
--- a/modules/hardware/video/intel.nix
+++ b/modules/hardware/video/intel.nix
@@ -1,7 +1,7 @@
 { pkgs, lib, config, ... }:
 {
   nixpkgs.config.packageOverrides = pkgs: {
-    vaapiIntel = pkgs.vaapiIntel.override { enableHybridCodec = true; };
+    intel-vaapi-driver = pkgs.intel-vaapi-driver.override { enableHybridCodec = true; };
   };
 
   environment.sessionVariables = lib.optionalAttrs config.programs.hyprland.enable {
@@ -27,7 +27,7 @@
     enable = true;
     extraPackages = with pkgs; [
       intel-media-driver
-      vaapiIntel
+      intel-vaapi-driver
       libva-vdpau-driver
       libvdpau-va-gl
     ];


### PR DESCRIPTION
#### Summary
The module `modules/hardware/video/intel.nix` still references the Intel VA-API driver via the legacy `vaapiIntel` alias. This is currently causing build failures during installation as the alias is not being resolved correctly in certain contexts. This PR updates all references to the canonical `intel-vaapi-driver` package name.

#### Changes
- Updated `vaapiIntel` to `intel-vaapi-driver` for consistency with pkgs name.
- Ensured `.override { enableHybridCodec = true; }` points to the correct package name.

#### Technical Details
The package is defined as `intel-vaapi-driver` in [`pkgs/by-name/in/intel-vaapi-driver/package.nix`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/in/intel-vaapi-driver/package.nix) and `vaapiIntel` does not work anymore. Using the canonical name instead of the alias is preferred for internal modules to prevent "package not found" errors (That's what happened to me 😭).

#### Testing
- [x] Verified package exists in Nixpkgs.
- [x] Confirmed `enableHybridCodec` option is valid in [source code](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/by-name/in/intel-vaapi-driver/package.nix#L75).
- [x] Verified configuration builds successfully with the updated name.
- [ ] Note: Compatibility was not tested on legacy hardware that exclusively requires this driver, such as Ivy Bridge (3rd Gen) or Haswell (4th Gen).
