### PR TITLE
Force Hyprland to use hyprlang config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -203,11 +203,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776964438,
-        "narHash": "sha256-AF0cby9Xuijr5qaFpYKbm1mExV956Hk233bel6QxpFw=",
+        "lastModified": 1778706808,
+        "narHash": "sha256-ihH1UnI6nYSOkjAg4QsOadg6sp2LxXnWO9urPbo3/hw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e09259dd2e147d35ef889784b51e89b0a10ffe15",
+        "rev": "9760b31dab3016fc6e422ca241cfeac605fb89c9",
         "type": "github"
       },
       "original": {

--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -107,6 +107,7 @@ in
         wayland.windowManager.hyprland = {
           enable = true;
           package = pkgs.hyprland;
+          configType = "hyprlang";
           plugins = [
             # inputs.hyprland-plugins.packages.${pkgs.stdenv.hostPlatform.system}.hyprwinwrap
             # inputs.hyprsysteminfo.packages.${pkgs.stdenv.hostPlatform.system}.default


### PR DESCRIPTION
Temporary workaround before the Lua transition.

Until the Hyprland configuration is fully migrated to Lua, we need to explicitly keep Home Manager generating the legacy Hyprlang config. 
Otherwise, users with home.stateVersion = "26.05" may have their Hyprland configuration generated as hyprland.lua, while their current setup still expects hyprland.conf, causing their Hyprland configuration to break after rebuild.