### PR TITLE
FEAT: Add skwd-wall wallpaper picker with variable-driven toggle

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -774,6 +774,37 @@
         "type": "github"
       }
     },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1768127708,
+        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -986,6 +1017,24 @@
         "url": "https://git.outfoxxed.me/outfoxxed/quickshell"
       }
     },
+    "quickshell_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1779430452,
+        "narHash": "sha256-zTslhsxLqUlRTML506iougTGzyR38Fzhzn7t4KDEuuE=",
+        "owner": "quickshell-mirror",
+        "repo": "quickshell",
+        "rev": "4b4fca3224ab977dc515ac0bb78d00b3dfa71e00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "quickshell-mirror",
+        "repo": "quickshell",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "betterfox": "betterfox",
@@ -1005,9 +1054,50 @@
         "nur": "nur",
         "nvchad4nix": "nvchad4nix",
         "plasma-manager": "plasma-manager",
+        "skwd-wall": "skwd-wall",
         "spicetify-nix": "spicetify-nix",
         "thunderbird-catppuccin": "thunderbird-catppuccin",
         "zen-browser": "zen-browser"
+      }
+    },
+    "skwd-daemon": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "lastModified": 1779106984,
+        "narHash": "sha256-OnkNK3szDMj+c3jVOodNPBW8Par7+xHhyuDS4YRN9kA=",
+        "owner": "liixini",
+        "repo": "skwd-daemon",
+        "rev": "1d40fc756944f7aa90be6fdf36d87bc0228a7a14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "liixini",
+        "repo": "skwd-daemon",
+        "type": "github"
+      }
+    },
+    "skwd-wall": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "quickshell": "quickshell_2",
+        "skwd-daemon": "skwd-daemon"
+      },
+      "locked": {
+        "lastModified": 1779352230,
+        "narHash": "sha256-3mGuD7BkqCRld84t626lo9ojRoaGnP1egLgS+0kpw/g=",
+        "owner": "liixini",
+        "repo": "skwd-wall",
+        "rev": "010da1e690835138636123ee805bd798bb63d45d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "liixini",
+        "repo": "skwd-wall",
+        "type": "github"
       }
     },
     "spicetify-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,10 @@
       url = "github:nix-community/nix4nvchad";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    skwd-wall = {
+      url = "github:liixini/skwd-wall";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/hosts/Default/variables.nix
+++ b/hosts/Default/variables.nix
@@ -10,6 +10,7 @@
   sddmTheme = "astronaut"; # astronaut, black_hole, purple_leaves, jake_the_dog, hyprland_kath
   defaultWallpaper = "galaxy.webp"; # Change with SUPER + SHIFT + W (Hyprland)
   hyprlockWallpaper = "galaxy.webp";
+  wallpaperPicker = "rofi"; # rofi, skwd-wall
 
   # Default Applications
   terminal = "kitty"; # kitty, alacritty

--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -8,7 +8,7 @@
 }:
 let
   inherit (lib) optional;
-  inherit (import ../../../hosts/${host}/variables.nix) bar;
+  inherit (import ../../../hosts/${host}/variables.nix) bar wallpaperPicker;
 in
 {
   imports = [
@@ -20,7 +20,8 @@ in
     ./programs/hypridle
     ./programs/hyprlock
   ]
-  ++ optional (bar != "hyprpanel" && bar != "wayle") ./programs/swaync;
+  ++ optional (bar != "hyprpanel" && bar != "wayle") ./programs/swaync
+  ++ optional (wallpaperPicker == "skwd-wall") ./programs/skwd-wall;
 
   environment.systemPackages = with pkgs; [
     pavucontrol

--- a/modules/desktop/hyprland/lua/binds.lua
+++ b/modules/desktop/hyprland/lua/binds.lua
@@ -77,7 +77,12 @@ hl.bind(mainMod .. " + CTRL + C", hl.dsp.exec_cmd("hyprpicker --autocopy --forma
 -- Window manager
 hl.bind(mainMod .. " + A", hl.dsp.exec_cmd(launcher .. " drun")) -- launch desktop applications
 hl.bind(mainMod .. " + SPACE", hl.dsp.exec_cmd(launcher .. " drun")) -- launch desktop applications
-hl.bind(mainMod .. " + SHIFT + W", hl.dsp.exec_cmd(launcher .. " wallpaper")) -- launch wallpaper switcher
+-- Wallpaper picker: rofi or skwd-wall based on wallpaperPicker variable
+if wallpaperPicker == "rofi" then
+  hl.bind(mainMod .. " + SHIFT + W", hl.dsp.exec_cmd(launcher .. " wallpaper")) -- launch wallpaper switcher (rofi)
+else
+  hl.bind(mainMod .. " + SHIFT + W", hl.dsp.exec_cmd("skwd wall toggle")) -- launch wallpaper switcher (skwd-wall)
+end
 hl.bind(mainMod .. " + Z", hl.dsp.exec_cmd(launcher .. " emoji")) -- launch emoji picker
 hl.bind(mainMod .. " + SHIFT + T", hl.dsp.exec_cmd(launcher .. " tmux")) -- launch tmux sessions
 hl.bind(mainMod .. " + G", hl.dsp.exec_cmd(launcher .. " games")) -- game launcher

--- a/modules/desktop/hyprland/lua/settings.lua
+++ b/modules/desktop/hyprland/lua/settings.lua
@@ -27,6 +27,9 @@ hl.on("hyprland.start", function()
 	hl.exec_cmd("rm '$XDG_CACHE_HOME/cliphist/db'")
 	hl.exec_cmd(batterynotify)
 	hl.exec_cmd("polkit-agent-helper-1")
+	if wallpaperPicker == "skwd-wall" then
+		hl.exec_cmd("skwd-daemon")
+	end
 end)
 
 hl.config({

--- a/modules/desktop/hyprland/programs/skwd-wall/default.nix
+++ b/modules/desktop/hyprland/programs/skwd-wall/default.nix
@@ -1,0 +1,96 @@
+{ pkgs, ... }:
+let
+  wallpaperDir = "${../../../../themes/wallpapers}";
+in
+{
+  home-manager.sharedModules = [
+    (_: {
+      # comment to disable matugen theming
+      home.packages = [ pkgs.matugen ];
+
+      xdg.configFile."skwd-wall/config.json" = {
+        text = builtins.toJSON {
+          compositor = "hyprland";
+          monitor = "";
+          general = {
+            locale = "";
+            closeOnSelection = false;
+            reopenAtLastSelection = false;
+          };
+          paths = {
+            wallpaper = wallpaperDir;
+            videoWallpaper = wallpaperDir;
+            cache = "";
+            templates = "";
+            scripts = "";
+            steam = "";
+            steamWorkshop = "";
+            steamWeAssets = "";
+          };
+          features = {
+            matugen = true;
+            ollama = false;
+            steam = false;
+            wallhaven = true;
+          };
+          colorSource = "magick";
+          ollama = {
+            url = "http://localhost:11434";
+            model = "gemma3:4b";
+            consolidateEnabled = true;
+          };
+          steam = {
+            apiKey = "";
+            username = "";
+          };
+          wallhaven = {
+            apiKey = "";
+          };
+          matugen = {
+            schemeType = "scheme-fidelity";
+            mode = "dark";
+          };
+          integrations = [
+            {
+              name = "skwd-wall";
+              template = "quickshell-colors.json";
+              output = "colors.json";
+            }
+            {
+              name = "skwd";
+              template = "quickshell-colors.json";
+              output = "~/.cache/skwd/colors.json";
+            }
+          ];
+          components = {
+            wallpaperSelector = {
+              displayMode = "slices";
+              sliceSpacing = -30;
+              hexScrollStep = 1;
+              customPresets = { };
+            };
+          };
+          wallpaperMute = true;
+          pickOnlyMode = false;
+          externalWallpaperCommand = "";
+          postProcessing = [ ];
+          performance = {
+            imageOptimizePreset = "balanced";
+            imageOptimizeResolution = "2k";
+            videoConvertPreset = "balanced";
+            videoConvertResolution = "2k";
+            autoOptimizeImages = false;
+            autoConvertVideos = false;
+            imageTrashDays = 7;
+            videoTrashDays = 7;
+            autoDeleteImageTrash = false;
+            autoDeleteVideoTrash = false;
+          };
+          paper = {
+            engine = "skwd-paper";
+          };
+        };
+      };
+    })
+  ];
+}

--- a/modules/desktop/hyprland/programs/skwd-wall/default.nix
+++ b/modules/desktop/hyprland/programs/skwd-wall/default.nix
@@ -1,8 +1,10 @@
-{ pkgs, ... }:
+{ inputs, pkgs, ... }:
 let
   wallpaperDir = "${../../../../themes/wallpapers}";
 in
 {
+  imports = [ inputs.skwd-wall.nixosModules.default ];
+  programs.skwd-wall.enable = true;
   home-manager.sharedModules = [
     (_: {
       # comment to disable matugen theming

--- a/modules/desktop/hyprland/variables.nix
+++ b/modules/desktop/hyprland/variables.nix
@@ -8,6 +8,7 @@ let
   inherit (lib) getExe;
   inherit (import ../../../hosts/${host}/variables.nix)
     bar
+    wallpaperPicker
     browser
     terminal
     fileManager
@@ -66,6 +67,7 @@ in
             capslockAsESC = ${lib.boolToString capslockAsESC}
             kbdLayout = "${kbdLayout}"
             kbdVariant = "${kbdVariant}"
+            wallpaperPicker = "${wallpaperPicker}"
           '';
         };
       }


### PR DESCRIPTION
## Overview

Adds [skwd-wall](https://github.com/liixini/skwd-wall) as an alternative wallpaper picker — a Quickshell-based selector with image/video/Wallpaper Engine support, color sorting by hue/saturation, and built-in matugen integration for automatic palette extraction from wallpapers.

## Architecture

The integration follows the existing `bar` variable pattern — a single variable in host config toggles between two implementations:

```
wallpaperPicker = "rofi"     # existing rofi picker (default, no change)
wallpaperPicker = "skwd-wall" # skwd-wall carousel picker
```

### Files changed

| File | Change |
|------|--------|
| `flake.nix` | Add `skwd-wall` flake input |
| `hosts/Default/variables.nix` | Add `wallpaperPicker` variable (default: `"rofi"`) |
| `modules/desktop/hyprland/default.nix` | Inherit `wallpaperPicker`, conditional import of `./programs/skwd-wall` |
| `modules/desktop/hyprland/variables.nix` | Pass `wallpaperPicker` as Lua variable |
| `modules/desktop/hyprland/lua/binds.lua` | Gate SUPER+SHIFT+W keybind: rofi picker or `skwd wall toggle` |
| `modules/desktop/hyprland/lua/settings.lua` | Gate `skwd-daemon` in exec-once when `wallpaperPicker == "skwd-wall"` |
| `modules/desktop/hyprland/programs/skwd-wall/` | **New module** — declarative config.json + matugen on PATH |

### Variable pattern

Same conditional import pattern as `bar`:

```nix
# default.nix
inherit (import ../../../hosts/${host}/variables.nix) bar wallpaperPicker;

imports = [ ... ]
  ++ optional (wallpaperPicker == "skwd-wall") ./programs/skwd-wall;
```

```lua
-- binds.lua
if wallpaperPicker == "rofi" then
  hl.bind(mainMod .. " + SHIFT + W", hl.dsp.exec_cmd(launcher .. " wallpaper"))
else
  hl.bind(mainMod .. " + SHIFT + W", hl.dsp.exec_cmd("skwd wall toggle"))
end
```

### skwd-wall module

The new module at `programs/skwd-wall/default.nix`:
- Generates `~/.config/skwd-wall/config.json` declaratively via `builtins.toJSON`
- Adds `matugen` to PATH for color extraction
- Configures compositor as `"hyprland"`, engine as `"skwd-paper"`, display mode as `"slices"` (carousel)
- Wallpaper path points to `modules/themes/wallpapers/`

## skwd-wall features

- Unified interface for images, videos, and Wallpaper Engine scenes
- 3 visual modes: parallelogram carousel (`slices`), traditional `grid`, hexagon `hex`
- Color sorting into 13 hue/saturation groups via ImageMagick
- Matugen integration with 15 built-in app templates (kitty, vscode, yazi, etc.)
- Wallhaven.cc browser, Steam Workshop browser
- Image/video optimization with configurable quality/resolution
- Multi-monitor support (Control+click to select target monitors)

## Adoption

To adopt this in your config:

1. Add `wallpaperPicker = "rofi"` to each host's `variables.nix` (preserves existing behavior)
2. Set `wallpaperPicker = "skwd-wall"` on any host where you want the new picker
3. Rebuild — `skwd-daemon` starts on login, SUPER+SHIFT+W opens the picker

No changes needed for hosts that keep `wallpaperPicker = "rofi"`.